### PR TITLE
feat: ajusta layout do mapa para tela cheia e adiciona navegacao para…

### DIFF
--- a/app/src/main/java/com/dcf2/orbita/model/Post.kt
+++ b/app/src/main/java/com/dcf2/orbita/model/Post.kt
@@ -11,5 +11,7 @@ data class Post(
     val descricao: String = "",
     val fotoUrl: String? = null,
     val dataObservacao: Timestamp = Timestamp.now(),
-    val likes: Int = 0
+    val likes: Int = 0,
+    val latitude: Double? = null,
+    val longitude: Double? = null
 )

--- a/app/src/main/java/com/dcf2/orbita/ui/dialog/NovaObservacaoDialog.kt
+++ b/app/src/main/java/com/dcf2/orbita/ui/dialog/NovaObservacaoDialog.kt
@@ -1,11 +1,13 @@
 package com.dcf2.orbita.ui.dialog
 
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -21,9 +23,12 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import coil.compose.AsyncImage // Certifique-se que tem o Coil no build.gradle
+import androidx.core.content.ContextCompat
+import coil.compose.AsyncImage
 import com.dcf2.orbita.viewmodel.MainViewModel
+import com.google.android.gms.location.LocationServices
 
+@SuppressLint("MissingPermission")
 @Composable
 fun NovaObservacaoDialog(
     onDismiss: () -> Unit,
@@ -33,7 +38,29 @@ fun NovaObservacaoDialog(
     var descricao by remember { mutableStateOf("") }
     var imageUri by remember { mutableStateOf<Uri?>(null) }
 
+    // Variáveis para guardar as coordenadas
+    var latitude by remember { mutableStateOf<Double?>(null) }
+    var longitude by remember { mutableStateOf<Double?>(null) }
+
     val context = LocalContext.current
+
+    // Tentar obter a localização assim que o Dialog abre
+    LaunchedEffect(Unit) {
+        val hasPermission = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+
+        if (hasPermission) {
+            val fusedLocationClient = LocationServices.getFusedLocationProviderClient(context)
+            fusedLocationClient.lastLocation.addOnSuccessListener { location ->
+                if (location != null) {
+                    latitude = location.latitude
+                    longitude = location.longitude
+                }
+            }
+        }
+    }
 
     // Seletor de Fotos Nativo
     val photoPickerLauncher = rememberLauncherForActivityResult(
@@ -51,7 +78,7 @@ fun NovaObservacaoDialog(
                 modifier = Modifier.padding(24.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Text("Novo Registro", style = MaterialTheme.typography.titleLarge, color = Color.White)
+                Text("Novo Registo", style = MaterialTheme.typography.titleLarge, color = Color.White)
 
                 Spacer(modifier = Modifier.height(16.dp))
 
@@ -80,7 +107,6 @@ fun NovaObservacaoDialog(
 
                 Spacer(modifier = Modifier.height(16.dp))
 
-                // Área da Imagem (Preview ou Botão de Adicionar)
                 if (imageUri != null) {
                     Box(modifier = Modifier.fillMaxWidth().height(150.dp)) {
                         AsyncImage(
@@ -91,7 +117,6 @@ fun NovaObservacaoDialog(
                                 .clip(RoundedCornerShape(8.dp)),
                             contentScale = ContentScale.Crop
                         )
-                        // Botão de Remover Imagem
                         IconButton(
                             onClick = { imageUri = null },
                             modifier = Modifier
@@ -118,15 +143,15 @@ fun NovaObservacaoDialog(
 
                 Spacer(modifier = Modifier.height(24.dp))
 
-                // Botão de Salvar com Loading
                 Button(
                     onClick = {
                         if (titulo.isNotEmpty()) {
-                            viewModel.criarPost(titulo, descricao, imageUri, context)
+                            // Passar latitude e longitude para o ViewModel
+                            viewModel.criarPost(titulo, descricao, imageUri, latitude, longitude, context)
                             onDismiss()
                         }
                     },
-                    enabled = !viewModel.isUploading, // Desabilita se estiver enviando
+                    enabled = !viewModel.isUploading,
                     colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFF2994A)),
                     modifier = Modifier.fillMaxWidth()
                 ) {

--- a/app/src/main/java/com/dcf2/orbita/ui/nav/MainNavHost.kt
+++ b/app/src/main/java/com/dcf2/orbita/ui/nav/MainNavHost.kt
@@ -44,7 +44,8 @@ fun MainNavHost(navController: NavHostController, viewModel: MainViewModel) {
         }
 
         //Rota Mapa
-        composable(BottomNavItem.Mapa.route) { MapPage(viewModel = viewModel)
+        composable(BottomNavItem.Mapa.route) {
+            MapPage(viewModel = viewModel, navController = navController)
         }
 
         //Rota ISS

--- a/app/src/main/java/com/dcf2/orbita/ui/page/MapPage.kt
+++ b/app/src/main/java/com/dcf2/orbita/ui/page/MapPage.kt
@@ -1,13 +1,18 @@
 package com.dcf2.orbita.ui.page
 
 import android.Manifest
-import android.annotation.SuppressLint
+import android.content.Context
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
+import android.graphics.drawable.BitmapDrawable
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material3.Button
@@ -21,18 +26,23 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
 import androidx.core.content.ContextCompat
+import coil.Coil
+import coil.request.ImageRequest
+import coil.request.SuccessResult
+import com.dcf2.orbita.ui.nav.BottomNavItem
 import com.dcf2.orbita.viewmodel.MainViewModel
+import com.google.android.gms.maps.model.BitmapDescriptor
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.*
 
 @Composable
-fun MapPage(viewModel: MainViewModel) {
+fun MapPage(viewModel: MainViewModel, navController: NavHostController) {
     val context = LocalContext.current
 
-    // Estado da Permissão
     var hasLocationPermission by remember {
         mutableStateOf(
             ContextCompat.checkSelfPermission(
@@ -42,84 +52,143 @@ fun MapPage(viewModel: MainViewModel) {
         )
     }
 
-    // Launcher para pedir permissão
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
         onResult = { isGranted -> hasLocationPermission = isGranted }
     )
 
-    // Posição Inicial da Câmera (Ex: Recife - Marco Zero)
     val recife = LatLng(-8.0631, -34.8711)
     val cameraPositionState = rememberCameraPositionState {
         position = CameraPosition.fromLatLngZoom(recife, 12f)
     }
 
-    Column(
+    val observacoes = viewModel.posts.toList()
+
+    // Removido a Column e o Text para o mapa ocupar todo o espaço do Scaffold!
+    Box(
         modifier = Modifier
             .fillMaxSize()
             .background(Color(0xFF050B14))
     ) {
-        Text(
-            text = "Mapa de Observação",
-            color = Color.White,
-            fontSize = 24.sp,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(16.dp)
-        )
+        if (hasLocationPermission) {
+            GoogleMap(
+                modifier = Modifier.fillMaxSize(),
+                cameraPositionState = cameraPositionState,
+                properties = MapProperties(
+                    isMyLocationEnabled = true,
+                    mapType = MapType.HYBRID
+                ),
+                uiSettings = MapUiSettings(
+                    myLocationButtonEnabled = true,
+                    zoomControlsEnabled = false
+                )
+            ) {
+                observacoes.forEach { post ->
+                    if (post.latitude != null && post.longitude != null) {
+                        val location = LatLng(post.latitude, post.longitude)
+                        val markerState = rememberMarkerState(key = post.id, position = location)
+                        val iconState = rememberCustomMarkerIcon(post.fotoUrl, context)
 
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(bottom = 80.dp) // Espaço para a BottomBar não cobrir o Google Logo
-        ) {
-            if (hasLocationPermission) {
-                GoogleMap(
-                    modifier = Modifier.fillMaxSize(),
-                    cameraPositionState = cameraPositionState,
-                    properties = MapProperties(
-                        isMyLocationEnabled = true,
-                        mapType = MapType.HYBRID // Modo Satélite/Híbrido combina com app espacial
-                    ),
-                    uiSettings = MapUiSettings(
-                        myLocationButtonEnabled = true,
-                        zoomControlsEnabled = false
-                    )
-                ) {
-                    // Exemplo de Marcador Fixo (Poderia vir do Firestore depois)
-                    Marker(
-                        state = MarkerState(position = recife),
-                        title = "Marco Zero",
-                        snippet = "Ótimo local para observar o nascer da lua."
-                    )
-                }
-            } else {
-                // Tela de "Permissão Necessária"
-                Column(
-                    modifier = Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.LocationOn,
-                        contentDescription = null,
-                        tint = Color(0xFFF2994A),
-                        modifier = Modifier.size(64.dp)
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        "Precisamos da sua localização",
-                        color = Color.White,
-                        fontWeight = FontWeight.Bold
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Button(
-                        onClick = { permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION) },
-                        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2D9CDB))
-                    ) {
-                        Text("Permitir Acesso")
+                        Marker(
+                            state = markerState,
+                            title = post.titulo,
+                            snippet = "Por: ${post.userName} (Clique para ir ao Feed)",
+                            icon = iconState.value ?: BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_ORANGE),
+                            onInfoWindowClick = {
+                                // Navega para o feed quando a caixa de info do pino for clicada
+                                navController.navigate(BottomNavItem.Home.route) {
+                                    popUpTo(navController.graph.startDestinationId) { saveState = true }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            }
+                        )
                     }
+                }
+            }
+        } else {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(
+                    imageVector = Icons.Default.LocationOn,
+                    contentDescription = null,
+                    tint = Color(0xFFF2994A),
+                    modifier = Modifier.size(64.dp)
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    "Precisamos da sua localização.",
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = { permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION) },
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2D9CDB))
+                ) {
+                    Text("Permitir Acesso")
                 }
             }
         }
     }
+}
+
+@Composable
+fun rememberCustomMarkerIcon(url: String?, context: Context): State<BitmapDescriptor?> {
+    val descriptorState = remember(url) { mutableStateOf<BitmapDescriptor?>(null) }
+
+    LaunchedEffect(url) {
+        if (url == null) return@LaunchedEffect
+
+        val imageLoader = Coil.imageLoader(context)
+        val request = ImageRequest.Builder(context)
+            .data(url)
+            .size(130, 130)
+            .allowHardware(false)
+            .build()
+
+        val result = (imageLoader.execute(request) as? SuccessResult)?.drawable
+        if (result is BitmapDrawable) {
+            val bitmap = result.bitmap
+            val circularBitmap = getCircularBitmapWithBorder(bitmap, 130)
+            descriptorState.value = BitmapDescriptorFactory.fromBitmap(circularBitmap)
+        }
+    }
+
+    return descriptorState
+}
+
+fun getCircularBitmapWithBorder(bitmap: Bitmap, size: Int): Bitmap {
+    val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(output)
+
+    val paint = Paint().apply {
+        isAntiAlias = true
+        isFilterBitmap = true
+    }
+
+    paint.color = android.graphics.Color.WHITE
+    paint.style = Paint.Style.FILL
+    canvas.drawCircle(size / 2f, size / 2f, size / 2f, paint)
+
+    val borderWidth = 8f
+    val radius = (size / 2f) - borderWidth
+
+    val imageOutput = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+    val imageCanvas = Canvas(imageOutput)
+
+    paint.color = android.graphics.Color.BLACK
+    imageCanvas.drawCircle(size / 2f, size / 2f, radius, paint)
+
+    paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
+    val scaledBitmap = Bitmap.createScaledBitmap(bitmap, size, size, false)
+    imageCanvas.drawBitmap(scaledBitmap, 0f, 0f, paint)
+
+    paint.xfermode = null
+    canvas.drawBitmap(imageOutput, 0f, 0f, paint)
+
+    return output
 }

--- a/app/src/main/java/com/dcf2/orbita/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/dcf2/orbita/viewmodel/MainViewModel.kt
@@ -130,4 +130,50 @@ class MainViewModel : ViewModel() {
         Curiosidade(3, "Buracos Negros", "Sem retorno", "Cosmos", Color(0xFF8E44AD)),
         Curiosidade(4, "Via Láctea", "Nossa casa", "Galáxia", Color(0xFF2980B9))
     )
+
+    fun criarPost(
+        titulo: String,
+        descricao: String,
+        imageUri: Uri?,
+        latitude: Double?,
+        longitude: Double?,
+        context: Context
+    ) {
+        viewModelScope.launch {
+            isUploading = true // Ativa loading
+
+            var urlDaFoto: String? = null
+
+            // 1. Upload da Imagem (se houver) para o Cloudinary
+            if (imageUri != null) {
+                urlDaFoto = ImageRepository.uploadImage(imageUri, context)
+                Log.d("OrbitaApp", "Upload finalizado: $urlDaFoto")
+            }
+
+            // 2. Cria o objeto Post COM A LOCALIZAÇÃO
+            val novoPost = Post(
+                userId = "user_temp_id",
+                userName = usuario.nome,
+                userAvatar = "",
+                titulo = titulo,
+                descricao = descricao,
+                fotoUrl = urlDaFoto,
+                likes = 0,
+                latitude = latitude, // GUARDA A LATITUDE
+                longitude = longitude // GUARDA A LONGITUDE
+            )
+
+            // 3. Salva no Firestore
+            val sucesso = journalRepository.addPost(novoPost)
+
+            if (sucesso) {
+                Log.d("OrbitaApp", "Salvo no Firestore com sucesso!")
+                fetchPosts() // Recarrega a lista para garantir sincronia no feed e no mapa
+            } else {
+                Log.e("OrbitaApp", "Erro ao salvar no Firestore")
+            }
+
+            isUploading = false // Desativa loading
+        }
+    }
 }


### PR DESCRIPTION
## 🚀 O que foi feito?
- Refatoração do `MapPage` para usar a renderização nativa de Bitmaps em background via `Canvas` (evitando a `IllegalStateException` do Compose Maps).
- Remoção de margens e títulos locais para permitir que o `GoogleMap` ocupe o `Scaffold` em tela cheia (Fullscreen).
- Integração do `NavHostController` no `MapPage`.
- O clique na caixa de informações (InfoWindow) do marcador no mapa agora redireciona suavemente o usuário de volta para o Feed (Aba Home).

## 📸 Funcionalidades
- Pins dinâmicos no mapa carregando imagens do Firebase/Cloudinary recortadas em formato circular e com borda branca.
- Transição de estado de visualização de Mapa -> Feed através da interação com o pino.

## 🔗 Issues Relacionadas
Closes #24 