### PR TITLE
feat: implementa UserRepository, integra dados reais do Firebase ao Perfil e apaga mocks

### DIFF
--- a/app/src/main/java/com/dcf2/orbita/model/Usuario.kt
+++ b/app/src/main/java/com/dcf2/orbita/model/Usuario.kt
@@ -1,0 +1,14 @@
+package com.dcf2.orbita.model
+
+data class Usuario(
+    val id: String = "",
+    val nome: String = "",
+    val email: String = "",
+    val avatarUrl: String = "",
+    val bio: String = "Explorando o universo com o Órbita.", // Bio padrão
+    val nivel: Int = 1,
+    val xp: Int = 0,
+    // Preparando o terreno para a Issue #8
+    val latitude: Double? = null,
+    val longitude: Double? = null
+)

--- a/app/src/main/java/com/dcf2/orbita/model/UsuarioPerfil.kt
+++ b/app/src/main/java/com/dcf2/orbita/model/UsuarioPerfil.kt
@@ -1,9 +1,0 @@
-package com.dcf2.orbita.model
-
-data class UsuarioPerfil(
-    val nome: String,
-    val handle: String, // @usuario
-    val nivel: Int,
-    val xp: Int,
-    val bio: String,
-)

--- a/app/src/main/java/com/dcf2/orbita/repository/UserRepository.kt
+++ b/app/src/main/java/com/dcf2/orbita/repository/UserRepository.kt
@@ -1,0 +1,49 @@
+package com.dcf2.orbita.repository
+
+import android.util.Log
+import com.dcf2.orbita.model.Usuario
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+class UserRepository {
+    private val db = FirebaseFirestore.getInstance()
+    private val usersCollection = db.collection("users")
+
+    // Salva ou atualiza um usuário no Firestore
+    suspend fun saveUser(usuario: Usuario): Boolean {
+        return try {
+            usersCollection.document(usuario.id).set(usuario).await()
+            Log.d("UserRepository", "Usuário salvo com sucesso!")
+            true
+        } catch (e: Exception) {
+            Log.e("UserRepository", "Erro ao salvar usuário: ${e.message}")
+            false
+        }
+    }
+
+    // Busca os dados do usuário pelo ID
+    suspend fun getUser(userId: String): Usuario? {
+        return try {
+            val document = usersCollection.document(userId).get().await()
+            if (document.exists()) {
+                document.toObject(Usuario::class.java)
+            } else {
+                null // Usuário ainda não existe no banco
+            }
+        } catch (e: Exception) {
+            Log.e("UserRepository", "Erro ao buscar usuário: ${e.message}")
+            null
+        }
+    }
+
+    // Função que usaremos na Issue #8 para o Mapa
+    suspend fun updateUserLocation(userId: String, lat: Double, lng: Double) {
+        try {
+            usersCollection.document(userId).update(
+                mapOf("latitude" to lat, "longitude" to lng)
+            ).await()
+        } catch (e: Exception) {
+            Log.e("UserRepository", "Erro ao atualizar localização: ${e.message}")
+        }
+    }
+}

--- a/app/src/main/java/com/dcf2/orbita/ui/page/PerfilPage.kt
+++ b/app/src/main/java/com/dcf2/orbita/ui/page/PerfilPage.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ExitToApp // Fallback caso o de cima n exista
+import androidx.compose.material.icons.filled.ExitToApp
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
@@ -13,18 +13,32 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
 import com.dcf2.orbita.viewmodel.MainViewModel
 
 @Composable
 fun PerfilPage(
     modifier: Modifier = Modifier,
     viewModel: MainViewModel,
-    onLogout: () -> Unit // <--- 1. Recebe a ação de logout
+    onLogout: () -> Unit
 ) {
-    val user = viewModel.usuario
+    // 1. Usa o utilizador real vindo do Firebase
+    val user = viewModel.usuarioLogado
+
+    // 2. Enquanto o Firebase não devolve os dados, mostra um "Loading"
+    if (user == null) {
+        Box(
+            modifier = modifier.fillMaxSize().background(Color(0xFF050B14)),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator(color = Color(0xFFF2994A))
+        }
+        return // Impede que o resto do ecrã seja desenhado sem dados
+    }
 
     Column(
         modifier = modifier
@@ -33,7 +47,7 @@ fun PerfilPage(
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        // Avatar
+        // Avatar (Com validação se a pessoa não tiver foto)
         Box(
             modifier = Modifier
                 .size(120.dp)
@@ -41,12 +55,28 @@ fun PerfilPage(
                 .background(Color.Gray),
             contentAlignment = Alignment.Center
         ) {
-            Icon(Icons.Default.Person, null, modifier = Modifier.size(80.dp), tint = Color.White)
+            if (user.avatarUrl.isNotEmpty()) {
+                AsyncImage(
+                    model = user.avatarUrl,
+                    contentDescription = "Foto de perfil",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                // Fallback para quem regista por Email/Senha sem foto
+                Icon(
+                    imageVector = Icons.Default.Person,
+                    contentDescription = "Sem foto",
+                    modifier = Modifier.size(80.dp),
+                    tint = Color.White
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(16.dp))
-        Text(user.nome, color = Color.White, fontSize = 24.sp, fontWeight = FontWeight.Bold)
-        Text(user.handle, color = Color(0xFF2D9CDB), fontSize = 16.sp)
+        Text(text = user.nome.ifEmpty { "Explorador" }, color = Color.White, fontSize = 24.sp, fontWeight = FontWeight.Bold)
+        // Substituímos o "@handle" pelo email da pessoa, já que é o que temos do Firebase por agora
+        Text(text = user.email, color = Color(0xFF2D9CDB), fontSize = 16.sp)
 
         Spacer(modifier = Modifier.height(24.dp))
 
@@ -57,7 +87,8 @@ fun PerfilPage(
         ) {
             StatItem("Nível", user.nivel.toString())
             StatItem("XP", user.xp.toString())
-            StatItem("Posts", viewModel.posts.filter { it.userName == "Você" }.size.toString())
+            // Conta os posts filtrando pelo ID real do utilizador, não pela string "Você"
+            StatItem("Posts", viewModel.posts.filter { it.userId == user.id }.size.toString())
         }
 
         Spacer(modifier = Modifier.height(32.dp))
@@ -86,13 +117,12 @@ fun PerfilPage(
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        // 3. Botão de Logout (Vermelho)
+        // Botão de Logout
         Button(
-            onClick = { onLogout() }, // Chama a função passada por parâmetro
-            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFC0392B)), // Vermelho escuro
+            onClick = { onLogout() },
+            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFC0392B)),
             modifier = Modifier.fillMaxWidth()
         ) {
-            // Tente Icons.AutoMirrored.Filled.ExitToApp se o Default não funcionar
             Icon(Icons.Default.ExitToApp, null)
             Spacer(modifier = Modifier.width(8.dp))
             Text("Sair da Conta")

--- a/app/src/main/java/com/dcf2/orbita/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/dcf2/orbita/viewmodel/MainViewModel.kt
@@ -13,7 +13,9 @@ import androidx.lifecycle.viewModelScope
 import com.dcf2.orbita.api.iss.IssApi
 import com.dcf2.orbita.model.*
 import com.dcf2.orbita.repository.ImageRepository
+import com.dcf2.orbita.repository.UserRepository
 import com.example.orbita.repository.JournalRepository
+import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import retrofit2.Retrofit
@@ -23,6 +25,11 @@ class MainViewModel : ViewModel() {
 
     // ---- REPOSITÓRIOS ----
     private val journalRepository = JournalRepository()
+    private val userRepository = UserRepository()
+
+    // --- ESTADO DO USUÁRIO LOGADO ---
+    var usuarioLogado by mutableStateOf<Usuario?>(null)
+        private set
 
     // --- ESTADOS DE UI ---
     var isUploading by mutableStateOf(false)
@@ -42,7 +49,34 @@ class MainViewModel : ViewModel() {
 
     init {
         startTrackingIss()
-        fetchPosts() // <--- AGORA CARREGAMOS DO FIREBASE AO INICIAR
+        fetchPosts()
+        fetchCurrentUser()
+    }
+
+    // FUNÇÃO QUE CARREGA OU CRIA O USUÁRIO REAL
+    fun fetchCurrentUser() {
+        val fbUser = FirebaseAuth.getInstance().currentUser
+        if (fbUser != null) {
+            viewModelScope.launch {
+                // Tenta buscar no banco
+                var user = userRepository.getUser(fbUser.uid)
+
+                // Se for a primeira vez que o usuário loga, ele não existe no Firestore ainda
+                if (user == null) {
+                    user = Usuario(
+                        id = fbUser.uid,
+                        nome = fbUser.displayName ?: "Astronauta Sem Nome",
+                        email = fbUser.email ?: "",
+                        avatarUrl = fbUser.photoUrl?.toString() ?: ""
+                    )
+                    // Salva no banco para a próxima vez
+                    userRepository.saveUser(user)
+                }
+
+                // Atualiza o estado da UI com o usuário real!
+                usuarioLogado = user
+            }
+        }
     }
 
     private fun startTrackingIss() {
@@ -77,103 +111,52 @@ class MainViewModel : ViewModel() {
     }
 
     // FUNÇÃO PRINCIPAL: Cria o post + Upload Imagem + Salva no Firestore
-    fun criarPost(titulo: String, descricao: String, imageUri: Uri?, context: Context) {
+    fun criarPost(titulo: String, descricao: String, imageUri: Uri?, latitude: Double?, longitude: Double?, context: Context) {
         viewModelScope.launch {
-            isUploading = true // Ativa loading
+            isUploading = true
 
             var urlDaFoto: String? = null
-
-            // 1. Upload da Imagem (se houver) para o Cloudinary
             if (imageUri != null) {
                 urlDaFoto = ImageRepository.uploadImage(imageUri, context)
                 Log.d("OrbitaApp", "Upload finalizado: $urlDaFoto")
             }
 
-            // 2. Cria o objeto Post
+            // SEGURANÇA: Só cria post se o usuário estiver logado
+            val currentUser = usuarioLogado ?: return@launch
+
             val novoPost = Post(
-                // O ID será gerado automaticamente se vazio, ou pelo Firestore
-                userId = "user_temp_id", // Futuramente, pegaremos do Firebase Auth
-                userName = usuario.nome, // Pega o nome do perfil atual
-                userAvatar = "",
+                userId = currentUser.id, // AGORA É REAL
+                userName = currentUser.nome, // AGORA É REAL
+                userAvatar = currentUser.avatarUrl, // AGORA É REAL (Foto do Google!)
                 titulo = titulo,
                 descricao = descricao,
                 fotoUrl = urlDaFoto,
-                likes = 0
+                likes = 0,
+                latitude = latitude,
+                longitude = longitude
             )
 
-            // 3. Salva no Firestore (O Pulo do Gato!)
             val sucesso = journalRepository.addPost(novoPost)
 
             if (sucesso) {
                 Log.d("OrbitaApp", "Salvo no Firestore com sucesso!")
-                fetchPosts() // Recarrega a lista para garantir sincronia
+                fetchPosts()
             } else {
                 Log.e("OrbitaApp", "Erro ao salvar no Firestore")
             }
-
-            isUploading = false // Desativa loading
+            isUploading = false
         }
     }
-
-    // --- DADOS ESTÁTICOS ---
-    var usuario by mutableStateOf(
-        UsuarioPerfil("Astronauta", "@astro_dev", 1, 150, "Explorando o universo.")
-    )
 
     val eventos = listOf(
         EventoAstronomico(1, "Eclipse Lunar", "14 Mar 2025", "Lua Vermelha", TipoEvento.ECLIPSE),
         EventoAstronomico(2, "Chuva de Líridas", "22 Abr 2025", "Meteoros.", TipoEvento.METEOROS)
     )
+
     val curiosidades = listOf(
         Curiosidade(1, "Júpiter", "O Gigante Gasoso", "Planeta", Color(0xFFE67E22)),
         Curiosidade(2, "Betelgeuse", "Prestes a explodir?", "Estrela", Color(0xFFC0392B)),
         Curiosidade(3, "Buracos Negros", "Sem retorno", "Cosmos", Color(0xFF8E44AD)),
         Curiosidade(4, "Via Láctea", "Nossa casa", "Galáxia", Color(0xFF2980B9))
     )
-
-    fun criarPost(
-        titulo: String,
-        descricao: String,
-        imageUri: Uri?,
-        latitude: Double?,
-        longitude: Double?,
-        context: Context
-    ) {
-        viewModelScope.launch {
-            isUploading = true // Ativa loading
-
-            var urlDaFoto: String? = null
-
-            // 1. Upload da Imagem (se houver) para o Cloudinary
-            if (imageUri != null) {
-                urlDaFoto = ImageRepository.uploadImage(imageUri, context)
-                Log.d("OrbitaApp", "Upload finalizado: $urlDaFoto")
-            }
-
-            // 2. Cria o objeto Post COM A LOCALIZAÇÃO
-            val novoPost = Post(
-                userId = "user_temp_id",
-                userName = usuario.nome,
-                userAvatar = "",
-                titulo = titulo,
-                descricao = descricao,
-                fotoUrl = urlDaFoto,
-                likes = 0,
-                latitude = latitude, // GUARDA A LATITUDE
-                longitude = longitude // GUARDA A LONGITUDE
-            )
-
-            // 3. Salva no Firestore
-            val sucesso = journalRepository.addPost(novoPost)
-
-            if (sucesso) {
-                Log.d("OrbitaApp", "Salvo no Firestore com sucesso!")
-                fetchPosts() // Recarrega a lista para garantir sincronia no feed e no mapa
-            } else {
-                Log.e("OrbitaApp", "Erro ao salvar no Firestore")
-            }
-
-            isUploading = false // Desativa loading
-        }
-    }
 }


### PR DESCRIPTION
## 🚀 O que foi feito?
- Criação da coleção `users` e do `UserRepository` para gerir os dados dos utilizadores no Firestore.
- Substituição dos dados "mockados" (`UsuarioPerfil`) pelos dados dinâmicos do `FirebaseAuth` integrados ao banco de dados (`Usuario`).
- Atualização do `MainViewModel` para injetar automaticamente o ID, Nome e Avatar reais do utilizador ao criar um `Post`.
- Tratamento de estado nulo (Loading) e fallback de imagem de perfil na `PerfilPage`.
- Contagem dinâmica e real de publicações no ecrã de Perfil.

## 🔗 Issues Relacionadas
Closes #7