### PR TITLE
feat: adiciona edicao de perfil, upload de foto via Cloudinary e navegacao de retorno

### DIFF
--- a/app/src/main/java/com/dcf2/orbita/ui/nav/MainNavHost.kt
+++ b/app/src/main/java/com/dcf2/orbita/ui/nav/MainNavHost.kt
@@ -54,11 +54,12 @@ fun MainNavHost(navController: NavHostController, viewModel: MainViewModel) {
         }
 
         // Rota Perfil
-        composable("perfil_route") { // ou o nome da sua rota
+        composable("perfil_route") {
             val context = LocalContext.current // Pega o contexto atual
 
             PerfilPage(
                 viewModel = viewModel,
+                navController = navController,
                 onLogout = {
                     // 1. Desloga do Firebase
                     FirebaseAuth.getInstance().signOut()

--- a/app/src/main/java/com/dcf2/orbita/ui/page/PerfilPage.kt
+++ b/app/src/main/java/com/dcf2/orbita/ui/page/PerfilPage.kt
@@ -1,35 +1,55 @@
 package com.dcf2.orbita.ui.page
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.ExitToApp
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
 import coil.compose.AsyncImage
+import com.dcf2.orbita.model.Usuario
 import com.dcf2.orbita.viewmodel.MainViewModel
 
 @Composable
 fun PerfilPage(
     modifier: Modifier = Modifier,
     viewModel: MainViewModel,
+    navController: NavController,
     onLogout: () -> Unit
 ) {
-    // 1. Usa o utilizador real vindo do Firebase
     val user = viewModel.usuarioLogado
+    var showSettingsDialog by remember { mutableStateOf(false) }
+    val context = LocalContext.current
 
-    // 2. Enquanto o Firebase não devolve os dados, mostra um "Loading"
+    // Lançador nativo para escolher imagens da galeria
+    val photoPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        if (uri != null) {
+            viewModel.atualizarFotoPerfil(uri, context)
+        }
+    }
+
     if (user == null) {
         Box(
             modifier = modifier.fillMaxSize().background(Color(0xFF050B14)),
@@ -37,7 +57,7 @@ fun PerfilPage(
         ) {
             CircularProgressIndicator(color = Color(0xFFF2994A))
         }
-        return // Impede que o resto do ecrã seja desenhado sem dados
+        return
     }
 
     Column(
@@ -47,12 +67,31 @@ fun PerfilPage(
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        // Avatar (Com validação se a pessoa não tiver foto)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Start
+        ) {
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(
+                    imageVector = Icons.Default.ArrowBack,
+                    contentDescription = "Voltar",
+                    tint = Color.White
+                )
+            }
+        }
+
+        // Bloco do Avatar
         Box(
             modifier = Modifier
                 .size(120.dp)
                 .clip(CircleShape)
-                .background(Color.Gray),
+                .background(Color.Gray)
+                .clickable {
+                    // Abre a galeria ao clicar na foto
+                    photoPickerLauncher.launch(
+                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                    )
+                },
             contentAlignment = Alignment.Center
         ) {
             if (user.avatarUrl.isNotEmpty()) {
@@ -63,7 +102,6 @@ fun PerfilPage(
                     contentScale = ContentScale.Crop
                 )
             } else {
-                // Fallback para quem regista por Email/Senha sem foto
                 Icon(
                     imageVector = Icons.Default.Person,
                     contentDescription = "Sem foto",
@@ -71,29 +109,40 @@ fun PerfilPage(
                     tint = Color.White
                 )
             }
+
+            // Overlay semitransparente com ícone de câmara para indicar que é editável
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.3f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.CameraAlt,
+                    contentDescription = "Alterar Foto",
+                    tint = Color.White.copy(alpha = 0.8f),
+                    modifier = Modifier.size(32.dp)
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(16.dp))
         Text(text = user.nome.ifEmpty { "Explorador" }, color = Color.White, fontSize = 24.sp, fontWeight = FontWeight.Bold)
-        // Substituímos o "@handle" pelo email da pessoa, já que é o que temos do Firebase por agora
         Text(text = user.email, color = Color(0xFF2D9CDB), fontSize = 16.sp)
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        // Stats
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceEvenly
         ) {
             StatItem("Nível", user.nivel.toString())
             StatItem("XP", user.xp.toString())
-            // Conta os posts filtrando pelo ID real do utilizador, não pela string "Você"
             StatItem("Posts", viewModel.posts.filter { it.userId == user.id }.size.toString())
         }
 
         Spacer(modifier = Modifier.height(32.dp))
 
-        // Bio
         Card(colors = CardDefaults.cardColors(containerColor = Color(0xFF1E293B))) {
             Column(modifier = Modifier.padding(16.dp).fillMaxWidth()) {
                 Text("Sobre Mim", color = Color.Gray, fontSize = 12.sp)
@@ -104,20 +153,18 @@ fun PerfilPage(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        // Botão Configurações
         Button(
-            onClick = {},
+            onClick = { showSettingsDialog = true },
             colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2C3E50)),
             modifier = Modifier.fillMaxWidth()
         ) {
             Icon(Icons.Default.Settings, null)
             Spacer(modifier = Modifier.width(8.dp))
-            Text("Configurações")
+            Text("Editar Perfil")
         }
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        // Botão de Logout
         Button(
             onClick = { onLogout() },
             colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFC0392B)),
@@ -128,6 +175,17 @@ fun PerfilPage(
             Text("Sair da Conta")
         }
     }
+
+    if (showSettingsDialog) {
+        ConfiguracoesDialog(
+            user = user,
+            onDismiss = { showSettingsDialog = false },
+            onSave = { novoNome, novaBio ->
+                viewModel.atualizarPerfil(novoNome, novaBio)
+                showSettingsDialog = false
+            }
+        )
+    }
 }
 
 @Composable
@@ -136,4 +194,52 @@ fun StatItem(label: String, value: String) {
         Text(value, color = Color(0xFFF2994A), fontSize = 20.sp, fontWeight = FontWeight.Bold)
         Text(label, color = Color.Gray, fontSize = 12.sp)
     }
+}
+
+@Composable
+fun ConfiguracoesDialog(user: Usuario, onDismiss: () -> Unit, onSave: (String, String) -> Unit) {
+    var nome by remember { mutableStateOf(user.nome) }
+    var bio by remember { mutableStateOf(user.bio) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Color(0xFF1E293B),
+        title = { Text("Editar Perfil", color = Color.White) },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = nome,
+                    onValueChange = { nome = it },
+                    label = { Text("Nome", color = Color.Gray) },
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = Color.White,
+                        unfocusedTextColor = Color.LightGray,
+                        focusedBorderColor = Color(0xFFF2994A)
+                    )
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = bio,
+                    onValueChange = { bio = it },
+                    label = { Text("Bio", color = Color.Gray) },
+                    modifier = Modifier.height(100.dp),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = Color.White,
+                        unfocusedTextColor = Color.LightGray,
+                        focusedBorderColor = Color(0xFFF2994A)
+                    )
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onSave(nome, bio) }) {
+                Text("Salvar", color = Color(0xFFF2994A), fontWeight = FontWeight.Bold)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancelar", color = Color.Gray)
+            }
+        }
+    )
 }

--- a/app/src/main/java/com/dcf2/orbita/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/dcf2/orbita/viewmodel/MainViewModel.kt
@@ -78,6 +78,44 @@ class MainViewModel : ViewModel() {
             }
         }
     }
+    // Atualiar Perfil
+    fun atualizarPerfil(novoNome: String, novaBio: String) {
+        val currentUser = usuarioLogado ?: return
+
+        // Cria uma cópia do utilizador com os novos dados
+        val updatedUser = currentUser.copy(nome = novoNome, bio = novaBio)
+
+        viewModelScope.launch {
+            // Guarda no Firestore usando o nosso UserRepository
+            val sucesso = userRepository.saveUser(updatedUser)
+            if (sucesso) {
+                // Se guardou no banco, atualiza a variável da tela
+                usuarioLogado = updatedUser
+                Log.d("OrbitaApp", "Perfil atualizado com sucesso!")
+            }
+        }
+    }
+
+    fun atualizarFotoPerfil(imageUri: Uri, context: Context) {
+        viewModelScope.launch {
+            val currentUser = usuarioLogado ?: return@launch
+
+            // Reutiliza o teu repositório de imagens (Cloudinary)
+            val urlDaFoto = ImageRepository.uploadImage(imageUri, context)
+
+            if (urlDaFoto != null) {
+                // Copia o utilizador atual alterando apenas a foto
+                val updatedUser = currentUser.copy(avatarUrl = urlDaFoto)
+
+                // Salva no banco de dados
+                val sucesso = userRepository.saveUser(updatedUser)
+                if (sucesso) {
+                    usuarioLogado = updatedUser // Atualiza a UI instantaneamente
+                    Log.d("OrbitaApp", "Foto de perfil atualizada com sucesso!")
+                }
+            }
+        }
+    }
 
     private fun startTrackingIss() {
         viewModelScope.launch {


### PR DESCRIPTION
## 🚀 O que foi feito?
Finalização da Issue de transição de dados "mockados" para dados reais do Firebase. O usuário agora tem controle total sobre o seu perfil.

- **Atualização de UI/UX no Perfil:**
  - Adicionado botão de retorno (`popBackStack`) no topo da página.
  - Avatar tornado interativo com *overlay* de câmera para indicar edição.
  - Implementação de um `AlertDialog` (ConfiguraçõesDialog) para edição do Nome e Bio.
- **Upload de Imagem (Perfil):**
  - Integração do `PickVisualMedia` para selecionar fotos da galeria.
  - O `MainViewModel` agora faz o upload da nova imagem para o Cloudinary e salva a URL no Firestore de forma transparente.
- **Sincronização:**
  - Alterações de nome, bio e foto refletem imediatamente na UI e no banco de dados.

## 🔗 Issues Relacionadas
Closes #7